### PR TITLE
Frontend: add .env.example documenting required environment variables

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,16 @@
+# Public app URL, used to build shareable/referral links
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# NextAuth
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=
+
+# OAuth providers (NextAuth)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+TWITTER_CLIENT_ID=
+TWITTER_CLIENT_SECRET=
+
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=


### PR DESCRIPTION
Adds a frontend/.env.example listing the environment variables the app expects (app URL, NextAuth config, and OAuth provider client IDs/secrets) so new contributors can configure their local setup easily.

Closes #621