### PR TITLE
Backend: add rate limiting to the puzzle answer submission endpoint

### DIFF
--- a/backend/src/rate-limiter/rate-limit.guard.ts
+++ b/backend/src/rate-limiter/rate-limit.guard.ts
@@ -2,7 +2,8 @@ import {
   CanActivate,
   ExecutionContext,
   Injectable,
-  ForbiddenException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { RateLimiterService } from './rate-limiter.service';
@@ -35,8 +36,9 @@ export class RateLimitGuard implements CanActivate {
     );
 
     if (isLimited) {
-      throw new ForbiddenException(
+      throw new HttpException(
         'Too many requests. Please try again later.',
+        HttpStatus.TOO_MANY_REQUESTS,
       );
     }
 


### PR DESCRIPTION
The puzzle-submission endpoint already applies RateLimitGuard (5 requests / 60s) to prevent brute-force guessing, but exceeding the limit returned a 403 Forbidden instead of a clear 429. This updates RateLimitGuard to throw an HttpException with HttpStatus.TOO_MANY_REQUESTS (429) so clients get an accurate, clear response when the limit is exceeded.

Closes #605