### PR TITLE
Frontend: add dark mode toggle

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -19,4 +19,14 @@ body {
     --brand-pink: 236 72 153;
     --brand-dark: 9 9 11;
   }
+
+  html.dark body {
+    background-color: #000000;
+    color: #ffffff;
+  }
+
+  html.light body {
+    background-color: #f8fafc;
+    color: #0f172a;
+  }
 }

--- a/frontend/app/layout.js
+++ b/frontend/app/layout.js
@@ -4,6 +4,7 @@ import "./globals.css";
 // import StoreProvider from "@/store/StoreProvider";
 import Providers from "@/lib/queryClient";
 import Navbar from "@/components/Navbar";
+import { ThemeProvider } from "@/lib/ThemeProvider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,12 +28,14 @@ export default function RootLayout({ children }) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Providers>
-          {/* <StoreProvider> */}
-          <Navbar />
-          {children}
-          {/* </StoreProvider> */}
-        </Providers>
+        <ThemeProvider>
+          <Providers>
+            {/* <StoreProvider> */}
+            <Navbar />
+            {children}
+            {/* </StoreProvider> */}
+          </Providers>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/components/Navbar.jsx
+++ b/frontend/components/Navbar.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Menu, X, Gamepad, Trophy, Book, User, Users } from "lucide-react";
+import ThemeToggle from "@/components/ThemeToggle";
 
 const NavigationHeader = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -65,10 +66,12 @@ const NavigationHeader = () => {
                   Connect Wallet
                 </Link>
               </Button>
+              <ThemeToggle />
             </div>
 
             {/* Mobile menu button */}
-            <div className="md:hidden">
+            <div className="md:hidden flex items-center space-x-2">
+              <ThemeToggle />
               <Button
                 variant="ghost"
                 size="icon"

--- a/frontend/components/ThemeToggle.jsx
+++ b/frontend/components/ThemeToggle.jsx
@@ -1,0 +1,23 @@
+"use client";
+import React from "react";
+import { Sun, Moon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/lib/ThemeProvider";
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      onClick={toggleTheme}
+      className="text-gray-300 hover:text-white"
+    >
+      {theme === "dark" ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </Button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/lib/ThemeProvider.jsx
+++ b/frontend/lib/ThemeProvider.jsx
@@ -1,0 +1,42 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+const STORAGE_KEY = "theme";
+const ThemeContext = createContext({ theme: "dark", toggleTheme: () => {} });
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState("dark");
+
+  useEffect(() => {
+    let stored = null;
+    try {
+      stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch {
+      // localStorage unavailable (e.g. privacy mode) — fall back to default theme
+    }
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // ignore persistence failures
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
Adds a light/dark mode toggle (ThemeProvider + ThemeToggle) wired into the root layout and Navbar. The chosen theme is persisted in localStorage and applied via a class on <html>, with base body colors respecting the selected theme.

Closes #601