### PR TITLE
feat(time-trial): add pagination to the leaderboard endpoint

### DIFF
--- a/backend/src/time-trial/dto/leaderboard-query.dto.ts
+++ b/backend/src/time-trial/dto/leaderboard-query.dto.ts
@@ -1,0 +1,37 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class LeaderboardQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Number of results per page',
+    default: 10,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+}
+
+export class PaginatedLeaderboardDto<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/backend/src/time-trial/providers/timetrial.service.ts
+++ b/backend/src/time-trial/providers/timetrial.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { TimeTrial } from '../time-trial.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { PaginatedLeaderboardDto } from '../dto/leaderboard-query.dto';
 
 @Injectable()
 export class TimetrialService {
@@ -44,12 +45,25 @@ export class TimetrialService {
     });
   }
 
-  // Optional: basic leaderboard logic
-  async getLeaderboard(puzzleId: string): Promise<TimeTrial[]> {
-    return await this.trialRepo.find({
+  // Paginated leaderboard: fastest completions first
+  async getLeaderboard(
+    puzzleId: string,
+    page = 1,
+    limit = 10,
+  ): Promise<PaginatedLeaderboardDto<TimeTrial>> {
+    const [items, total] = await this.trialRepo.findAndCount({
       where: { puzzleId, completed: true },
       order: { endTime: 'ASC' },
-      take: 10,
+      skip: (page - 1) * limit,
+      take: limit,
     });
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit) || 0,
+    };
   }
 }

--- a/backend/src/time-trial/time-trial.controller.ts
+++ b/backend/src/time-trial/time-trial.controller.ts
@@ -1,9 +1,11 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { TimetrialService } from './providers/timetrial.service';
+import { LeaderboardQueryDto } from './dto/leaderboard-query.dto';
 import {
   ApiBody,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -72,17 +74,22 @@ export class TimeTrialController {
   }
 
   @Get('leaderboard/:puzzleId')
-  @ApiOperation({ summary: 'Get top 10 fastest completions for a puzzle' })
+  @ApiOperation({ summary: 'Get paginated fastest completions for a puzzle' })
   @ApiParam({
     name: 'puzzleId',
     description: 'Puzzle ID to get leaderboard for',
     example: 'puzzle-456',
   })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 10 })
   @ApiResponse({
     status: 200,
-    description: 'Top performers for the specified puzzle',
+    description: 'Paginated top performers for the specified puzzle',
   })
-  getLeaderboard(@Param('puzzleId') puzzleId: string) {
-    return this.timeTrialService.getLeaderboard(puzzleId);
+  getLeaderboard(
+    @Param('puzzleId') puzzleId: string,
+    @Query() query: LeaderboardQueryDto,
+  ) {
+    return this.timeTrialService.getLeaderboard(puzzleId, query.page, query.limit);
   }
 }


### PR DESCRIPTION
## Summary
`GET /time-trial/leaderboard/:puzzleId` previously always returned a hardcoded top 10. Adds `page`/`limit` query params (validated via a new `LeaderboardQueryDto`) and returns `{ items, total, page, limit, totalPages }` using `findAndCount` with `skip`/`take`.

Closes #606

https://claude.ai/code/session_01AdKUdoVWCGSSDhKvhSKc6J