### PR TITLE
feat(onchain): emit event when an NFT reward is minted

### DIFF
--- a/onchain/src/contracts/scavenger_hunt_nft.cairo
+++ b/onchain/src/contracts/scavenger_hunt_nft.cairo
@@ -25,6 +25,7 @@ pub mod ScavengerHuntNFT {
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
+    use starknet::event::EventEmitter;
     use starknet::ContractAddress;
     use super::Levels;
 
@@ -55,6 +56,15 @@ pub mod ScavengerHuntNFT {
         SRC5Event: SRC5Component::Event,
         #[flat]
         AccessControlEvent: AccessControlComponent::Event,
+        BadgeMinted: BadgeMinted,
+    }
+
+    /// Emitted whenever a level badge is minted to a recipient.
+    #[derive(Drop, starknet::Event)]
+    pub struct BadgeMinted {
+        pub recipient: ContractAddress,
+        pub level: Levels,
+        pub token_id: u256,
     }
 
     #[constructor]
@@ -107,6 +117,9 @@ pub mod ScavengerHuntNFT {
 
             // Mint exactly one token
             self.erc1155.mint_with_acceptance_check(recipient, token_id, 1_u256, array![].span());
+
+            // Emit a domain event recording the mint
+            self.emit(BadgeMinted { recipient, level, token_id });
         }
 
         // Check if a player has a specific level badge

--- a/onchain/tests/test_scavenger_hunt_nft_badge_event.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft_badge_event.cairo
@@ -90,17 +90,13 @@ fn test_minting_two_levels_emits_one_event_each() {
                 (
                     contract_address,
                     NFTEvent::BadgeMinted(
-                        BadgeMinted {
-                            recipient, level: Levels::Easy, token_id: easy_token_id,
-                        },
+                        BadgeMinted { recipient, level: Levels::Easy, token_id: easy_token_id },
                     ),
                 ),
                 (
                     contract_address,
                     NFTEvent::BadgeMinted(
-                        BadgeMinted {
-                            recipient, level: Levels::Medium, token_id: medium_token_id,
-                        },
+                        BadgeMinted { recipient, level: Levels::Medium, token_id: medium_token_id },
                     ),
                 ),
             ],

--- a/onchain/tests/test_scavenger_hunt_nft_badge_event.cairo
+++ b/onchain/tests/test_scavenger_hunt_nft_badge_event.cairo
@@ -1,0 +1,108 @@
+use onchain::contracts::scavenger_hunt_nft::{
+    IScavengerHuntNFTDispatcher, IScavengerHuntNFTDispatcherTrait,
+};
+use onchain::contracts::scavenger_hunt_nft::ScavengerHuntNFT;
+use onchain::contracts::scavenger_hunt_nft::ScavengerHuntNFT::{BadgeMinted, Event as NFTEvent};
+use onchain::interface::Levels;
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, spy_events, start_cheat_caller_address,
+    stop_cheat_caller_address, EventSpyAssertionsTrait,
+};
+use starknet::ContractAddress;
+
+// Regression tests for #614: ScavengerHuntNFT should emit a BadgeMinted
+// event whenever a level badge is minted.
+
+fn deploy_contract(scavenger_hunt_contract: ContractAddress) -> ContractAddress {
+    let base_uri: ByteArray = "https://scavenger_hunt_nft.com/";
+
+    let mut constructor_calldata: Array<felt252> = ArrayTrait::new();
+
+    base_uri.serialize(ref constructor_calldata);
+    constructor_calldata.append(scavenger_hunt_contract.into());
+
+    let contract = declare("ScavengerHuntNFT").unwrap().contract_class();
+
+    let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
+
+    contract_address
+}
+
+fn deploy_mock_receiver() -> ContractAddress {
+    let contract = declare("MockERC1155Receiver").unwrap().contract_class();
+    let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+
+    contract_address
+}
+
+#[test]
+fn test_mint_emits_badge_minted_event() {
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    let contract_address = deploy_contract(scavenger_hunt_address);
+    let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
+
+    let recipient = deploy_mock_receiver();
+    let level = Levels::Easy;
+    let expected_token_id: u256 = level.into();
+
+    let mut spy = spy_events();
+
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+    scavenger_hunt.mint_level_badge(recipient, level);
+    stop_cheat_caller_address(contract_address);
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    NFTEvent::BadgeMinted(
+                        BadgeMinted { recipient, level, token_id: expected_token_id },
+                    ),
+                ),
+            ],
+        );
+}
+
+#[test]
+fn test_minting_two_levels_emits_one_event_each() {
+    let scavenger_hunt_address: ContractAddress = 0x456.try_into().unwrap();
+
+    let contract_address = deploy_contract(scavenger_hunt_address);
+    let scavenger_hunt = IScavengerHuntNFTDispatcher { contract_address };
+
+    let recipient = deploy_mock_receiver();
+
+    let mut spy = spy_events();
+
+    start_cheat_caller_address(contract_address, scavenger_hunt_address);
+    scavenger_hunt.mint_level_badge(recipient, Levels::Easy);
+    scavenger_hunt.mint_level_badge(recipient, Levels::Medium);
+    stop_cheat_caller_address(contract_address);
+
+    let easy_token_id: u256 = Levels::Easy.into();
+    let medium_token_id: u256 = Levels::Medium.into();
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    NFTEvent::BadgeMinted(
+                        BadgeMinted {
+                            recipient, level: Levels::Easy, token_id: easy_token_id,
+                        },
+                    ),
+                ),
+                (
+                    contract_address,
+                    NFTEvent::BadgeMinted(
+                        BadgeMinted {
+                            recipient, level: Levels::Medium, token_id: medium_token_id,
+                        },
+                    ),
+                ),
+            ],
+        );
+}


### PR DESCRIPTION
## Summary
`ScavengerHuntNFT::mint_level_badge` minted the ERC-1155 token but never emitted a domain-specific event from the NFT contract itself. Adds a `BadgeMinted { recipient, level, token_id }` event, emitted right after the mint succeeds.

Covered by new tests in `test_scavenger_hunt_nft_badge_event.cairo` verifying the event (and its data) is emitted for a single mint and for multiple mints to the same recipient.

Closes #614

https://claude.ai/code/session_01AdKUdoVWCGSSDhKvhSKc6J