### PR TITLE
fix(frontend): fix responsive layout for puzzle cards on mobile

### DIFF
--- a/frontend/components/puzzles/roadmap/PuzzleCard.tsx
+++ b/frontend/components/puzzles/roadmap/PuzzleCard.tsx
@@ -11,14 +11,14 @@ export default function PuzzleCard({ puzzle }: Props) {
   const isUpcoming = new Date(releaseDate) > new Date();
 
   return (
-    <div className="bg-white text-gray-900 rounded-2xl shadow-lg w-[280px] md:w-[320px] p-4 flex flex-col items-center hover:scale-105 transition-transform duration-300">
+    <div className="bg-white text-gray-900 rounded-2xl shadow-lg w-[min(85vw,280px)] sm:w-[320px] p-4 flex flex-col items-center hover:scale-105 transition-transform duration-300">
       <div className="relative w-full h-40 mb-4 rounded-xl overflow-hidden">
         <Image
           src={imageUrl}
           alt={title}
-          layout="fill"
-          objectFit="cover"
-          className="rounded-xl"
+          fill
+          sizes="(max-width: 640px) 85vw, 320px"
+          className="rounded-xl object-cover"
         />
       </div>
       <h2 className="text-xl font-semibold mb-1 text-center">{title}</h2>


### PR DESCRIPTION
## Summary
`PuzzleCard` had two mobile layout bugs:
- Fixed pixel widths (`w-[280px]`/`md:w-[320px]`) that didn't shrink for narrower phone viewports, so the card could overflow the screen.
- The image used the legacy Next.js `layout="fill" objectFit="cover"` props, which no longer exist in Next.js 14 (this project's version) - the image was not actually filling/covering its container.

Fixes both: the card now scales with `w-[min(85vw,280px)] sm:w-[320px]`, and the image uses the current `fill` prop + `object-cover` class with a `sizes` hint.

Closes #602

https://claude.ai/code/session_01AdKUdoVWCGSSDhKvhSKc6J