### PR TITLE
feat(frontend): add progress bar showing puzzles completed vs total

### DIFF
--- a/frontend/components/PuzzleComponent.jsx
+++ b/frontend/components/PuzzleComponent.jsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import PuzzleProgressBar from "./PuzzleProgressBar";
 // puzzle data to simulate data coming in
 const puzzleData = {
   title: "Simple Math",
@@ -18,6 +19,8 @@ const puzzleData = {
   puzzle:
     "How many  confirmations are typically recommended for StarkNet transactions?",
   hint: "StarkNet has faster finality than most L1s",
+  completedPuzzles: 2,
+  totalPuzzles: 8,
 };
 
 const PuzzleComponent = () => {
@@ -38,6 +41,10 @@ const PuzzleComponent = () => {
         </CardDescription>
       </CardHeader>
       <CardContent>
+        <PuzzleProgressBar
+          completed={puzzleData.completedPuzzles}
+          total={puzzleData.totalPuzzles}
+        />
         <form className="space-y-6">
           <label htmlFor="puzzle">{puzzleData.puzzle}</label>
           <div className="space-y-4">

--- a/frontend/components/PuzzleProgressBar.jsx
+++ b/frontend/components/PuzzleProgressBar.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+/**
+ * Shows how many puzzles a player has completed out of the total available,
+ * as a labelled progress bar.
+ */
+const PuzzleProgressBar = ({ completed, total }) => {
+  const safeTotal = total > 0 ? total : 0;
+  const safeCompleted = Math.min(Math.max(completed, 0), safeTotal || completed);
+  const percentage = safeTotal > 0 ? Math.round((safeCompleted / safeTotal) * 100) : 0;
+
+  return (
+    <div className="w-full mb-4">
+      <div className="flex justify-between text-xs md:text-sm text-gray-300 mb-1">
+        <span>Progress</span>
+        <span>
+          {safeCompleted} / {safeTotal} puzzles completed
+        </span>
+      </div>
+      <div
+        className="w-full h-2 rounded-full bg-white/10 overflow-hidden"
+        role="progressbar"
+        aria-valuenow={percentage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Puzzles completed"
+      >
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-purple-500 to-pink-500 transition-all duration-300"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PuzzleProgressBar;


### PR DESCRIPTION
## Summary
Adds a reusable `PuzzleProgressBar` component showing "X / Y puzzles completed" with an accessible (`role="progressbar"`, ARIA attributes) filled bar, and wires it into `PuzzleComponent`.

Closes #598

https://claude.ai/code/session_01AdKUdoVWCGSSDhKvhSKc6J